### PR TITLE
harden release publishing and supply-chain controls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+.github/workflows/ @cawalch
+.github/dependabot.yml @cawalch
+Cargo.lock @cawalch
+Cargo.toml @cawalch
+package.json @cawalch
+pnpm-lock.yaml @cawalch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,8 +5,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
   CARGO_INCREMENTAL: "1"
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 "on":
   push:
     branches:
@@ -96,27 +95,31 @@ jobs:
           echo "test_matrix={\"settings\":$TEST_MATRIX,\"node\":[\"20\",\"22\"]}" >> $GITHUB_OUTPUT
   build:
     needs: setup
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.build_matrix) }}
     name: stable - ${{ matrix.settings.target }} - node@20
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
       - name: Install
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -127,18 +130,26 @@ jobs:
             target/
           key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
+      - name: Verify Cargo lockfile
+        run: cargo metadata --locked --format-version 1
       - name: Build
         run: ${{ matrix.settings.build }}
         shell: bash
+      - name: Generate artifact attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: "*.node"
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: bindings-${{ matrix.settings.target }}
           path: "*.node"
           if-no-files-found: error
   test-bindings:
     name: Test bindings on ${{ matrix.settings.target }} - node@${{ matrix.node }}
+    permissions:
+      contents: read
     needs:
       - setup
       - build
@@ -147,19 +158,19 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.test_matrix) }}
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
           architecture: ${{ matrix.settings.architecture }}
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: bindings-${{ matrix.settings.target }}
           path: .
@@ -172,22 +183,32 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    permissions:
+      contents: write
+      id-token: write
     needs:
       - build
       - test-bindings
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20
+          node-version: 22.14.0
           cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - name: Update npm
+        run: npm install --global npm@^11.5.1
+      - name: Print publish toolchain
+        run: |
+          node --version
+          npm --version
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: artifacts
       - name: create npm dirs
@@ -199,8 +220,6 @@ jobs:
         shell: bash
       - name: Publish
         run: |
-          npm config set provenance true
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
           if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
             npm publish --tag next --access public
           else
@@ -208,4 +227,4 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+"on":
+  pull_request:
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - package.json
+      - pnpm-lock.yaml
+      - .github/workflows/**
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: moderate
+          fail-on-scopes: runtime, development, unknown

--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@
 npm install @litko/yara-x
 ```
 
+### Release Integrity
+
+Releases are built on GitHub-hosted runners and published to npm with Trusted Publishing and provenance. Native `.node` artifacts are also covered by GitHub artifact attestations.
+
+Verify npm registry signatures and provenance attestations after install:
+
+```bash
+npm audit signatures
+```
+
+Verify downloaded native artifacts against GitHub attestations:
+
+```bash
+gh attestation verify path/to/yara-x.*.node -R cawalch/node-yara-x
+```
+
 ### Basic Example
 
 ```javascript

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately through GitHub Security Advisories for this repository.
+
+Do not open a public issue for a suspected vulnerability. Include the affected version, a minimal reproduction if possible, and any relevant crash output or rule input.
+
+## Supply Chain Controls
+
+`@litko/yara-x` is a native Node.js package, so releases are treated as supply-chain sensitive artifacts.
+
+- Release builds run in GitHub Actions on GitHub-hosted runners.
+- npm packages are published with npm Trusted Publishing and provenance, backed by GitHub OIDC and Sigstore transparency logs.
+- Native `.node` artifacts are attested with GitHub artifact attestations.
+- Release dependencies are installed with frozen lockfiles.
+- Commits to protected branches are required to be signed.
+- Pull requests that change dependency manifests or lockfiles run GitHub Dependency Review.
+- Release publishing does not require a long-lived npm publish token.
+- Dependabot tracks npm, Cargo, and GitHub Actions dependencies.
+
+## Verifying a Release
+
+Consumers can verify npm registry signatures and provenance attestations for installed dependencies:
+
+```sh
+npm audit signatures
+```
+
+Downloaded native artifacts can be verified against GitHub artifact attestations:
+
+```sh
+gh attestation verify path/to/yara-x.*.node -R cawalch/node-yara-x
+```
+
+## Supported Versions
+
+Security fixes are released in the latest published version. If a fix cannot be safely backported, the advisory will state the affected versions and recommended upgrade path.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,23 +25,23 @@ importers:
         version: 24.6.2
     optionalDependencies:
       '@litko/yara-x-darwin-arm64':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.5.1
+        version: 0.5.1
       '@litko/yara-x-darwin-x64':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.5.1
+        version: 0.5.1
       '@litko/yara-x-linux-arm64-gnu':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.5.1
+        version: 0.5.1
       '@litko/yara-x-linux-x64-gnu':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.5.1
+        version: 0.5.1
       '@litko/yara-x-win32-arm64-msvc':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.5.1
+        version: 0.5.1
       '@litko/yara-x-win32-x64-msvc':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.5.1
+        version: 0.5.1
 
 packages:
 
@@ -188,38 +188,38 @@ packages:
       '@types/node':
         optional: true
 
-  '@litko/yara-x-darwin-arm64@0.5.0':
-    resolution: {integrity: sha512-Og7Phjx8UaALDJHgcX7UaRToiR+Jzpiq+h7d6RQde7AdhMZcunYsiEc47UVJAJ5Kqi1vD4dpyczTT0kvugGj5g==}
+  '@litko/yara-x-darwin-arm64@0.5.1':
+    resolution: {integrity: sha512-Kr3uYMgJq1kRVAxrAh0PhqbN7972lxsKTb9naNKyhgLRyQykYvbKkFJx5ykjZnDsBCriTCDlaHzBj1FVJHQE9g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@litko/yara-x-darwin-x64@0.5.0':
-    resolution: {integrity: sha512-1X2TGdWAF2oQ+PT+5zPSvPUmtRmGRtNi/JI6+LzyFOccrZJRD7sinyscg5ABqXUV8n9IcVCjcCHyFzCoG1ofoA==}
+  '@litko/yara-x-darwin-x64@0.5.1':
+    resolution: {integrity: sha512-23OK2FNK1Pu6oAhKj5MYRuBfi7Z36yqp05SUKACD/BTT/pbHDrWxfpf6VsvEG4Jz2GmTFmsMleNpNabFLDG+KQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@litko/yara-x-linux-arm64-gnu@0.5.0':
-    resolution: {integrity: sha512-DCfJZxXgSOUHFRmsO/O5x+wFl0tpxRqhcJY1M4wR577Q0KJiQFfqwch1bmqC6YABjezaJCY8RSAWUo33W0TB1w==}
+  '@litko/yara-x-linux-arm64-gnu@0.5.1':
+    resolution: {integrity: sha512-kF9Obc6a8pKuJO7sSGuEKvcS/POb7E/FMrl7p0hMr6xgCYCX4qXFXdiAVu/WEt6cjEugRp7KSRD4dla6lB1nsw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  '@litko/yara-x-linux-x64-gnu@0.5.0':
-    resolution: {integrity: sha512-fZelUMMLg6Lfcb2SYrkbKvd8ntHqTNBPOypJRkj+dab9w5BPAO1o8Npa2zvzjT7w3VWmncUudhTLqUAWcAvRwA==}
+  '@litko/yara-x-linux-x64-gnu@0.5.1':
+    resolution: {integrity: sha512-H7DEQCXDOwYlKZUC4StvoTuM6DxqrtuSo6kidTcZlOiLT2Nfjmbrm0vuqRQt25XKui+cNmOw0RZKtl/HyFByGg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  '@litko/yara-x-win32-arm64-msvc@0.5.0':
-    resolution: {integrity: sha512-FLtMXyGdyuXdY9h79c1W0DEAst8eiri1AIiVLVTDOqq1pNSgphDmtq2xDZNgntLnrswR7iit9it4ynGt4MvphQ==}
+  '@litko/yara-x-win32-arm64-msvc@0.5.1':
+    resolution: {integrity: sha512-sLXsyObxaBu2WFXPFRck66BVPuuzxZDurYHqULV+qGIsf9KSoXlxWZ2JhhMidutJMbA1WCHSYywDH/RFbfB9GQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
-  '@litko/yara-x-win32-x64-msvc@0.5.0':
-    resolution: {integrity: sha512-7hpMrTGY6m/Fx+2DJjcBmwW8fzbtm77JUE5sC9AbGozd/rfnW43EF7QyJ0RVhSgHp1x8izJkTWje/y4wyGWSiQ==}
+  '@litko/yara-x-win32-x64-msvc@0.5.1':
+    resolution: {integrity: sha512-0OIzJKnSB29kNxtVphdjI607cJ8ZmPiczZ+ze93kSxWgvJpso14Hi3iWy7N6jSgcaT9PE5xkPvrL2rPuTOKkrQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -850,22 +850,22 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.6.2
 
-  '@litko/yara-x-darwin-arm64@0.5.0':
+  '@litko/yara-x-darwin-arm64@0.5.1':
     optional: true
 
-  '@litko/yara-x-darwin-x64@0.5.0':
+  '@litko/yara-x-darwin-x64@0.5.1':
     optional: true
 
-  '@litko/yara-x-linux-arm64-gnu@0.5.0':
+  '@litko/yara-x-linux-arm64-gnu@0.5.1':
     optional: true
 
-  '@litko/yara-x-linux-x64-gnu@0.5.0':
+  '@litko/yara-x-linux-x64-gnu@0.5.1':
     optional: true
 
-  '@litko/yara-x-win32-arm64-msvc@0.5.0':
+  '@litko/yara-x-win32-arm64-msvc@0.5.1':
     optional: true
 
-  '@litko/yara-x-win32-x64-msvc@0.5.0':
+  '@litko/yara-x-win32-x64-msvc@0.5.1':
     optional: true
 
   '@napi-rs/cli@3.6.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.6.2)':


### PR DESCRIPTION
- Switch npm publishing workflow toward Trusted Publishing/OIDC by removing npm token auth from CI
- Require frozen pnpm installs and verify Cargo.lock during native builds
- Add GitHub artifact attestations for built .node binaries
- Pin GitHub Actions to full commit SHAs and reduce default workflow permissions
- Add Dependency Review, Dependabot config, CODEOWNERS, and SECURITY.md
- Document npm provenance and artifact verification commands
- Update pnpm-lock.yaml to align optional native packages with 0.5.1