### PR TITLE
ci: add explicit permissions to verify-signatures workflow

### DIFF
--- a/.github/workflows/verify-signatures.yml
+++ b/.github/workflows/verify-signatures.yml
@@ -4,6 +4,9 @@ name: Verify Sigstore Signatures
 # Those branches are created exclusively by prepare-release.yml, which signs
 # commits with Gitsign (Sigstore keyless). Regular developer PRs are not
 # Gitsign-signed and must not be checked here.
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Summary

Resolves a CodeQL alert (`actions/missing-workflow-permissions`): the
`verify-signatures.yml` workflow had no explicit `permissions` block,
meaning it inherited the repository/organization default token permissions.

## Changes

- Added `permissions: contents: read` to `.github/workflows/verify-signatures.yml`

`contents: read` is sufficient since this workflow only checks out code
and runs `gitsign verify` — it never writes anything.