### PR TITLE
ci: update dtolnay/rust-toolchain to current master digest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -128,7 +128,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - name: Install
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}


### PR DESCRIPTION
## Summary

Pins `dtolnay/rust-toolchain` to the current `master` branch tip (`3c5f7ea`) instead of the outdated `stable` branch pin (`29eef336`).

## Problem

The previous pinned commit referenced a deleted `stable` branch of `dtolnay/rust-toolchain`. That version lacks support for `cargo metadata`, causing CI to fail with:

```
unexpected argument 'metadata'
```

## Fix

- Updates the pinned SHA from `29eef336d9b2848a0b548edc03f92a220660cdb8` to `3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9` (current `master` tip)
- Maintains SHA digest pinning for supply-chain protection
- No changes to action inputs (`toolchain: stable`, `targets` matrix)