### PR TITLE
ci: remove unnecessary pnpm install from test-bindings job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -169,28 +169,18 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 10.18.0
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
-          cache: pnpm
           architecture: ${{ matrix.settings.architecture }}
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bindings-${{ matrix.settings.target }}
           path: .
-      - name: List packages
-        run: ls -R .
-        shell: bash
       - name: Test bindings
-        run: pnpm test
+        run: node --test --test-concurrency 1 __test__/index.spec.mjs
   publish:
     name: Publish
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The `test-bindings` GHA job is slow, particularly on `x86_64-pc-windows-msvc` with Node 22. The bottleneck is `pnpm install --frozen-lockfile` which downloads and extracts all devDependencies and optionalDependencies — even though none of them are needed at test runtime.

## Root cause

`index.js` uses **zero external runtime dependencies**. It only imports:
- `node:fs` (built-in)
- `child_process` (built-in, only on Linux for musl detection)

The native `.node` binary is already downloaded as an artifact from the build job. All `devDependencies` (`@emnapi/core`, `@emnapi/runtime`, `@napi-rs/cli`, `@napi-rs/wasm-runtime`, `@types/node`) are build-only.

## Changes

- **Removed** `pnpm/action-setup` — not needed when not running pnpm
- **Removed** `cache: pnpm` on `setup-node` — no store to cache
- **Removed** `pnpm install --frozen-lockfile` — downloads deps for no benefit
- **Removed** `ls -R .` debug step
- **Changed** `pnpm test` → `node --test --test-concurrency 1 __test__/index.spec.mjs`

## Impact

Saves ~30-60 seconds per run, most impactful on Windows where `pnpm install` + node\_modules extraction is notably slower due to file I/O overhead.