### PR TITLE
chore: prepare v0.6.0 release

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@litko/yara-x-darwin-arm64",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "cpu": [
     "arm64"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@litko/yara-x-darwin-x64",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "cpu": [
     "x64"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@litko/yara-x-linux-arm64-gnu",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "cpu": [
     "arm64"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@litko/yara-x-linux-x64-gnu",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "cpu": [
     "x64"
   ],

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@litko/yara-x-win32-arm64-msvc",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "cpu": [
     "arm64"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@litko/yara-x-win32-x64-msvc",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "cpu": [
     "x64"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@litko/yara-x",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "main": "index.js",
   "types": "index.d.ts",
   "packageManager": "pnpm@10.18.0",


### PR DESCRIPTION
Prepares v0.6.0 for release. This PR only bumps package versions and refreshes the pnpm lockfile. Publishing remains gated by creating the GitHub release after merge.

## Changes since v0.5.2

### New APIs
- `addRuleSources()` — batch rule compilation, eliminates O(n²) performance issue with incremental rule addition
- `setMatchContextSize()` on Scanner — configurable match context size
- `contextData` and `contextMatchOffset` fields on `MatchData`

### Dependency upgrades
- `yara-x` (Rust): 1.16.0 → 1.17.0
- `napi` (Rust): 3.8.6 → 3.9.2
- `@emnapi/core`: 1.11.0 → 1.11.1
- `@emnapi/runtime`: 1.11.0 → 1.11.1
- `@napi-rs/cli`: 3.7.1 → 3.7.2

### CI/infra
- Dropped Node 20 from test matrix (EOL, incompatible with pnpm 10)
- Various GitHub Actions and toolchain updates

### Validation
- All **74 tests pass** ✅
- `cargo metadata --locked` validates Cargo.lock ✅
- Commit signed with Gitsign (Sigstore keyless) ✅