### PR TITLE
fix(ci): include event_name in concurrency group

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ permissions:
   release:
     types: [published]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 jobs:
   setup:


### PR DESCRIPTION
The CI workflow concurrency group was `CI-refs/heads/main` for both push and release events. With `cancel-in-progress: true`, the push event would cancel the release publish run.

Fix: add `${{ github.event_name }}` to the concurrency group so push and release runs are independent.

**Also fixes the v0.6.0 publish that was blocked by this.**