### PR TITLE
chore(ci): add OpenSSF Scorecard analysis + published badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,57 @@
+# OpenSSF Scorecard: runs weekly and on every push to main, publishes results to the
+# public Scorecard API (api.securityscorecards.dev) so the badge in the README stays live.
+# Docs: https://github.com/ossf/scorecard-action
+name: Scorecard
+
+permissions:
+  contents: read
+
+on:
+  # Runs on the default branch keep the published results current.
+  push:
+    branches:
+      - main
+  # Re-run when branch protection rules change (affects the Branch-Protection check).
+  branch_protection_rule:
+  # Weekly scheduled run captures dependency/supply-chain drift between pushes.
+  schedule:
+    - cron: "33 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF to code scanning.
+      security-events: write
+      # Required to publish results to the public Scorecard API for the badge.
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes to api.securityscorecards.dev — required for the README badge.
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 7
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @litko/yara-x
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/github/cawalch/node-yara-x/badge)](https://scorecard.dev/viewer/?uri=github.com/cawalch/node-yara-x)
+
 ## Features
 
 - High Performance: Built with [napi-rs](https://napi-rs.com) and [VirusTotal/yara-x](https://github.com/VirusTotal/yara-x)


### PR DESCRIPTION
## Summary

Adds a weekly + on-push **OpenSSF Scorecard** analysis that publishes results to the public Scorecard API, and a live badge in the README.

## Changes

- **`.github/workflows/scorecard.yml`** — new workflow:
  - Triggers: `push` to `main`, weekly schedule, and `branch_protection_rule`
  - \`publish_results: true\` → pushes to \`api.securityscorecards.dev\` (powers the badge)
  - Uploads SARIF to **GitHub code scanning** + keeps a 7-day artifact
  - \`permissions: security-events: write, id-token: write\` (both required for publish + SARIF upload)
  - **Every action pinned by SHA** to satisfy the Pinned-Dependencies check, matching the repo's existing convention. Reused the repo's existing \`checkout@v6\` / \`upload-artifact@v7\` pins; added \`ossf/scorecard-action@v2.4.3\` and \`codeql-action/upload-sarif@v3.36.2\`.
- **`README.md`** — badge under the title:
  \`![OpenSSF Scorecard](https://api.securityscorecards.dev/github/cawalch/node-yara-x/badge)\`

## Required one-time repo setting (after merge)

The SARIF upload needs code scanning enabled. On a **public** repo, enable **Settings → Code security → Code Scanning → Default Setup** (free), then the first run publishes results and the badge renders.

## Suggested follow-ups to raise the score (solo repo)

- **Branch-Protection** (biggest lift): enable a rule on \`main\` (Settings → Branches → Require status checks). Scorecard scores this 0 for a solo repo unless a rule exists.
- **Token-Permissions**: already clean (top-level \`contents: read\`, no \`pull_request_target\`). No action needed.
- Existing **Dependabot** \`github-actions\` config will keep the new SHAs current automatically.

## Checklist

- [x] Workflow YAML validated
- [x] All actions pinned by SHA (full-commit)
- [x] \`publish_results: true\` for badge
- [x] Badge added to README