### PR TITLE
fix(ci): Scorecard — use commit SHAs, not annotated-tag object SHAs

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -52,6 +52,6 @@ jobs:
           retention-days: 7
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem

The merged Scorecard workflow (\`#114\`) failed on publish with:

\`\`\`
imposter commit: 99c09fe975337306107572b4fdf4db224cf8e2f2 does not belong to ossf/scorecard-action
\`\`\`

## Root cause

I pinned \`ossf/scorecard-action\` and \`github/codeql-action\` to their **annotated-tag object** SHAs instead of the **commit** SHAs they dereference to. The Scorecard signature verifier only accepts genuine commit SHAs (a tag-object SHA isn't a commit, so it's rejected as an imposter).

\`git ls-remote --tags --refs\` showed only the tag ref with no peeled \`^{}\` line, which misleadingly looked like a lightweight tag — but the GitHub API is authoritative and reports \`"type": "tag"\`.

## Fix

Resolved each tag to its commit via the GitHub API (\`git/refs → git/tags → object.sha\`):

| Action | Tag object (was) | Commit (now) |
|---|---|---|
| ossf/scorecard-action v2.4.3 | \`99c09fe9…\` | \`4eaacf0543bb3f2c246792bd56e8cdeffafb205a\` |
| github/codeql-action v3.36.2 | \`8272c299…\` | \`dd903d2e4f5405488e5ef1422510ee31c8b32357\` |

\`actions/checkout@v6\` (\`df4cb1c…\`) and \`actions/upload-artifact@v7\` (\`043fb46d…\`) were verified \`type: commit\` via the API — already correct, unchanged.

## Verification

- [x] Both new SHAs confirmed \`type: commit\` via GitHub API
- [x] Workflow YAML validates
- [x] Diff is exactly the 2 SHA lines

After merge, the next \`push\`/scheduled run should publish successfully and the badge will populate.