### PR TITLE
fix(scorecard): badge path, CodeQL v4, and least-privilege hardening

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,7 +2,7 @@ name: Create Release
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 permissions:
-  contents: write
+  contents: read
 "on":
   workflow_dispatch:
     inputs:
@@ -23,6 +23,8 @@ jobs:
     name: Create GitHub release
     runs-on: ubuntu-latest
     if: github.repository == 'cawalch/node-yara-x'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -2,9 +2,7 @@ name: Prepare Release
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 "on":
   workflow_dispatch:
     inputs:
@@ -31,6 +29,10 @@ jobs:
     name: Prepare release PR
     runs-on: ubuntu-latest
     if: github.repository == 'cawalch/node-yara-x'
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -52,6 +52,6 @@ jobs:
           retention-days: 7
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @litko/yara-x
 
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/github/cawalch/node-yara-x/badge)](https://scorecard.dev/viewer/?uri=github.com/cawalch/node-yara-x)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cawalch/node-yara-x/badge)](https://scorecard.dev/viewer/?uri=github.com/cawalch/node-yara-x)
 
 ## Features
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,13 @@
 
 ## Reporting a Vulnerability
 
-Please report suspected vulnerabilities privately through GitHub Security Advisories for this repository.
+Please report suspected vulnerabilities privately through [GitHub Security Advisories](https://github.com/cawalch/node-yara-x/security/advisories/new).
 
 Do not open a public issue for a suspected vulnerability. Include the affected version, a minimal reproduction if possible, and any relevant crash output or rule input.
+
+## Disclosure Timelines
+
+We aim to acknowledge vulnerability reports within 72 hours and to provide a fix or mitigation within 90 days of disclosure. Coordinated disclosure timelines may be adjusted by mutual agreement with the reporter.
 
 ## Supply Chain Controls
 


### PR DESCRIPTION
Fixes the badge rendering, the CodeQL v3 deprecation warning, and lifts several Scorecard checks. Current **aggregate score: 6.2**.

## 1. Badge renders as a link (not an image) — FIXED

The README badge URL used the legacy path ``/github/{owner}/{repo}/badge``, which now **404s**. The live Scorecard API serves badges at ``/projects/github.com/{owner}/{repo}/badge``.

- Verified live: \`https://api.scorecard.dev/projects/github.com/cawalch/node-yara-x/badge\` → \`302 image/svg+xml\`
- JSON is indexed and live at \`/projects/github.com/cawalch/node-yara-x\` (score \`6.2\`)
- The earlier 404 was **not** propagation — it was the wrong path. After merge the badge will render immediately.

## 2. CodeQL Action v3 deprecation — FIXED

```
Warning: CodeQL Action v3 will be deprecated in December 2026.
```

Bumped \`upload-sarif\` to **v4.36.2**, commit \`8aad20d150bbac5944a9f9d289da16a4b0d87c1e\` (dereferenced from the annotated tag — same care as the earlier imposter-commit fix).

## 3. Score lift (code-actionable checks)

| Check | Before | Fix | After (est.) |
|---|---|---|---|
| **Token-Permissions** | 0 | Move top-level \`contents: write\` → job-level in \`create-release.yml\` + \`prepare-release.yml\`; top-level → \`contents: read\` | ~8–10 |
| **Security-Policy** | 4 | Add explicit reporting **link** + a **disclosure timeline** (vuln/disclos/days) to \`SECURITY.md\` | ~10 |

These were the two biggest *code-actionable* wins.

## Remaining 0-scoring checks (need repo settings or external steps — not in this PR)

For a solo repo, these can't be fixed purely by code. Listed so the path to a higher score is clear:

- **Branch-Protection (3)** — biggest remaining win. In **Settings → Branches → main**: require status checks, require up-to-date branches, require linear history, and **do not allow bypassing for admins**. (~+5)
- **Code-Review (0)** — \"0/13 approved changesets\". Requires \"require approvals\" in branch protection. GitHub won't let a solo owner self-approve, so this is a known solo-repo limitation.
- **Signed-Releases (0)** — old releases v0.4.0/0.5.0/0.5.1 predate provenance. The next release cut with the current \`--provenance\` publish flow will lift this.
- **Vulnerabilities (8)** — \`RUSTSEC-2025-0141\`, \`RUSTSEC-2023-0071\`. A \`cargo update\` / \`cargo audit\` pass (separate PR).
- **CII-Best-Practices (0)** — claim a badge at https://www.bestpractices.dev (external form).
- **Fuzzing (0)** — optional; add a CIFuzz workflow (heavy for a native module).
- **Pinned-Dependencies (9)** — \`npm install --global npm@^11.5.1\` flagged as not-hash-pinned. Low value / awkward for a global tool install.

## Verification

- [x] All 3 workflow YAMLs parse; top-level perms = \`contents: read\`, writes correctly scoped to the jobs that need them
- [x] Badge URL returns \`302 image/svg+xml\`; JSON returns score \`6.2\`
- [x] CodeQL SHA dereferenced from annotated tag to commit (no repeat of the imposter-commit issue)