### PR TITLE
ci(scorecard): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,6 +13,8 @@ on:
       - main
   # Re-run when branch protection rules change (affects the Branch-Protection check).
   branch_protection_rule:
+  # Allow on-demand runs (e.g. after a branch-protection change).
+  workflow_dispatch:
   # Weekly scheduled run captures dependency/supply-chain drift between pushes.
   schedule:
     - cron: "33 6 * * 1"


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to the Scorecard workflow so runs can be triggered on demand.

## Why
The previous `branch_protection_rule`-triggered run fired the instant the protection-rule PUT started and captured the **pre-protection** commit state — so the published score (7.2, Branch-Protection still 3) didn't reflect the newly active branch protection. A `workflow_dispatch` lets us force a clean run against the current state after settings changes, instead of waiting for the next `push` / weekly `schedule`.

## Change
One entry added to the `on:` block:

```yaml
  workflow_dispatch:
```

No other behavior changed; YAML validated.

## After merge
```bash
gh workflow run scorecard.yml --ref main
```
