### PR TITLE
fix(release): sync optionalDependencies with package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,11 +65,11 @@
     "rust"
   ],
   "optionalDependencies": {
-    "@litko/yara-x-darwin-arm64": "0.5.2",
-    "@litko/yara-x-darwin-x64": "0.5.2",
-    "@litko/yara-x-linux-arm64-gnu": "0.5.2",
-    "@litko/yara-x-linux-x64-gnu": "0.5.2",
-    "@litko/yara-x-win32-arm64-msvc": "0.5.2",
-    "@litko/yara-x-win32-x64-msvc": "0.5.2"
+    "@litko/yara-x-darwin-arm64": "0.6.0",
+    "@litko/yara-x-darwin-x64": "0.6.0",
+    "@litko/yara-x-linux-arm64-gnu": "0.6.0",
+    "@litko/yara-x-linux-x64-gnu": "0.6.0",
+    "@litko/yara-x-win32-arm64-msvc": "0.6.0",
+    "@litko/yara-x-win32-x64-msvc": "0.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,23 +25,23 @@ importers:
         version: 25.9.3
     optionalDependencies:
       '@litko/yara-x-darwin-arm64':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.6.0
+        version: 0.6.0
       '@litko/yara-x-darwin-x64':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.6.0
+        version: 0.6.0
       '@litko/yara-x-linux-arm64-gnu':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.6.0
+        version: 0.6.0
       '@litko/yara-x-linux-x64-gnu':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.6.0
+        version: 0.6.0
       '@litko/yara-x-win32-arm64-msvc':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.6.0
+        version: 0.6.0
       '@litko/yara-x-win32-x64-msvc':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.6.0
+        version: 0.6.0
 
 packages:
 
@@ -188,38 +188,38 @@ packages:
       '@types/node':
         optional: true
 
-  '@litko/yara-x-darwin-arm64@0.5.2':
-    resolution: {integrity: sha512-OYKL3q22NVP+PB+nFuQDoJMdjxwhh5JTzIu+oD0HZL807WRvqaA3UFKc5d/m/wgKBNpH4JSTo1ruKRm8ZBdARA==}
+  '@litko/yara-x-darwin-arm64@0.6.0':
+    resolution: {integrity: sha512-sRqBk9P8DkvZIxeueRnR1HlTb+liEVSyN/k4KGQcMt3MIw2csjAZzI32sbEgEQ2lbDYm2uDvYAYo6QlamMciJw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@litko/yara-x-darwin-x64@0.5.2':
-    resolution: {integrity: sha512-UKp8q+EY+ZyZl4w3K+JWYaoAoycmfELdGzV5H/uAe2zUwb/xSZVLoH+/WI32YLcZj9yygc+KIITLCbbl7dW7OQ==}
+  '@litko/yara-x-darwin-x64@0.6.0':
+    resolution: {integrity: sha512-nAs2ROhRLnpVQA/1O7CXV/xmXLtTPUILafLYYMo6FHa9iGIjaAAHJEa2k15Sb2bKrz9Mw6BCJQeKkujfzV3oWg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@litko/yara-x-linux-arm64-gnu@0.5.2':
-    resolution: {integrity: sha512-IcsDM4HRRuPK2G5Qv2tuMXJsaCeLKxLrgadBYwsNV3UfqZ79dxpXCymHe1FviG3aWOXxveGfTJfBHktl9KEiyQ==}
+  '@litko/yara-x-linux-arm64-gnu@0.6.0':
+    resolution: {integrity: sha512-CC9reHVvWDAiAMc2scSkxBn/q/19nBwAB4jwuGQ4FZum0nwNJnSq31f55ZVXErhh4cybImcFOhMHoeaj0iVwrg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  '@litko/yara-x-linux-x64-gnu@0.5.2':
-    resolution: {integrity: sha512-pmr67yMwjSRx3q7+GdS7m8UlZux3R4Cj63ttL2iJQAnLfmSVHFibgERPDm39m512DWXN6bd3axq2rtT1ptO1KQ==}
+  '@litko/yara-x-linux-x64-gnu@0.6.0':
+    resolution: {integrity: sha512-WsD5N75dUzdouPecEawOlzJ6psbEGtUlbu55qf+7AN7wkLr/kW8+9dF5i3VQPaBE1ywD6Knd7m9El1OrM9cq0A==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  '@litko/yara-x-win32-arm64-msvc@0.5.2':
-    resolution: {integrity: sha512-0UV8sqI3MPkF16fR9eGZbtN0wJExIny4Iww/pjx11cAvenD9CVGWRVXjc7XhSkph81CBbzgZ8b6dn4Ba5E/FpA==}
+  '@litko/yara-x-win32-arm64-msvc@0.6.0':
+    resolution: {integrity: sha512-Vq2fU4zazB2QifgCehqFmdWraj97ki/mEIcwC5i4fUUfua8oX3fNwbWqzZCt3wEt8qEL2aZGeb2TSqjgxrrTHg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
-  '@litko/yara-x-win32-x64-msvc@0.5.2':
-    resolution: {integrity: sha512-oh/NrufjDjiVaCvj9VeD9GCa+6uYMHeXcrtf7fQ4kNgC53lxqK6/w8dNJJmwkh92Gc+hYwYq5Z/0fQ+fhTmuUg==}
+  '@litko/yara-x-win32-x64-msvc@0.6.0':
+    resolution: {integrity: sha512-ENez0TUObtf2RO+1yOcXiIvq9gU6hJ59m2ePqql5+7yV0F99DWhzY9NUs6sBB97e5FDAFwk0NK4oprn1BsJW0w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -852,22 +852,22 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.3
 
-  '@litko/yara-x-darwin-arm64@0.5.2':
+  '@litko/yara-x-darwin-arm64@0.6.0':
     optional: true
 
-  '@litko/yara-x-darwin-x64@0.5.2':
+  '@litko/yara-x-darwin-x64@0.6.0':
     optional: true
 
-  '@litko/yara-x-linux-arm64-gnu@0.5.2':
+  '@litko/yara-x-linux-arm64-gnu@0.6.0':
     optional: true
 
-  '@litko/yara-x-linux-x64-gnu@0.5.2':
+  '@litko/yara-x-linux-x64-gnu@0.6.0':
     optional: true
 
-  '@litko/yara-x-win32-arm64-msvc@0.5.2':
+  '@litko/yara-x-win32-arm64-msvc@0.6.0':
     optional: true
 
-  '@litko/yara-x-win32-x64-msvc@0.5.2':
+  '@litko/yara-x-win32-x64-msvc@0.6.0':
     optional: true
 
   '@napi-rs/cli@3.7.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.9.3)':

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -42,6 +42,20 @@ const packageJsonPath = join(root, "package.json");
 const packageJson = await readJson(packageJsonPath);
 const nextVersion = bumpVersion(packageJson.version, releaseType);
 
+// Keep the root optionalDependencies (the native binary sub-packages) in sync
+// with the package version. They must point at the same version the
+// npm/<platform>/ sub-packages are published at, otherwise installs resolve
+// to a previous release's native binaries (a real off-by-one version skew).
+const subPackagePrefix = `${packageJson.name}-`;
+
+if (packageJson.optionalDependencies) {
+  for (const dep of Object.keys(packageJson.optionalDependencies)) {
+    if (dep.startsWith(subPackagePrefix)) {
+      packageJson.optionalDependencies[dep] = nextVersion;
+    }
+  }
+}
+
 packageJson.version = nextVersion;
 
 await writeJson(packageJsonPath, packageJson);


### PR DESCRIPTION
Fixes a systematic off-by-one version skew in `optionalDependencies` that ships every release pointing at the *previous* version's native binaries.

## The bug

`prepare-release.mjs` bumps the root `version` and each `npm/<platform>/package.json` version, but **never syncs the root `optionalDependencies`**. Git history confirms they've only ever been updated ad-hoc in unrelated commits.

Result: **published `@litko/yara-x@0.6.0` on npm declares `optionalDependencies` at `0.5.2`**, even though the `0.6.0` sub-packages exist on the registry:

```
@litko/yara-x@0.6.0         -> optionalDependencies: @litko/yara-x-*@0.5.2  ❌
@litko/yara-x-darwin-arm64@0.6.0  exists on npm                            ✅ (never pulled)
```

So `npm install @litko/yara-x@0.6.0` resolves the **0.5.2 native binaries**, not 0.6.0.

## Verification of the skew across releases

| Published root | optionalDependencies declared |
|---|---|
| `0.5.2` | `0.5.1` ❌ |
| `0.6.0` | `0.5.2` ❌ |

## The fix (two parts)

**1. `scripts/prepare-release.mjs`** — bump `optionalDependencies` to `nextVersion` alongside everything else. Scoped to deps matching `<rootName>-` so it only touches this package's native sub-packages:

```js
const subPackagePrefix = `${packageJson.name}-`;
if (packageJson.optionalDependencies) {
  for (const dep of Object.keys(packageJson.optionalDependencies)) {
    if (dep.startsWith(subPackagePrefix)) {
      packageJson.optionalDependencies[dep] = nextVersion;
    }
  }
}
```

Dry-run tested: a simulated `0.6.1` bump correctly syncs all 6 optionalDeps.

**2. `package.json`** — correct the current state `0.5.2` → `0.6.0` (matches the version and the `npm/<platform>/` sub-packages already at 0.6.0).

## ⚠️ The published 0.6.0 on npm is immutable

This PR fixes the source so the **next** release is correct, but it cannot fix what's already on the registry. To actually correct `npm install` behavior for the 0.6.x line, the next release (`0.6.1`) must be cut after this merges — that release will publish with correct `optionalDependencies`.

The native ABI is stable across these versions (napi), so 0.6.0 wrapper + 0.5.2 binaries likely *run*, but it's still wrong: consumers don't get the 0.6.0 native code and the versions are misleading.

## Checklist
- [x] `package.json` optionalDependencies corrected to 0.6.0
- [x] `prepare-release.mjs` syncs optionalDependencies on every release
- [x] Both files validated (JSON parse + `node --check`)
- [x] Dry-run sim confirms the script syncs correctly
- [x] Scope-limited to this package's sub-packages only
