### PR TITLE
fix(release): sync optionalDependencies at publish time, not prepare time

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -242,6 +242,24 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Sync optionalDependencies to current version
+        # The native sub-packages were just published above. Sync the root
+        # optionalDependencies to the package version so installs resolve the
+        # matching native binaries, not a previous release's. This runs at
+        # publish time (not prepare time) because the new versions only exist
+        # on npm after the sub-package publish loop above.
+        run: |
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const v = pkg.version;
+            const prefix = pkg.name + "-";
+            for (const dep of Object.keys(pkg.optionalDependencies || {})) {
+              if (dep.startsWith(prefix)) pkg.optionalDependencies[dep] = v;
+            }
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+            console.log("Synced optionalDependencies to", v);
+          '
       - name: Publish main package
         # Publish root package last (--ignore-scripts skips prepublishOnly / napi prepublish
         # which would try to create a GitHub release that already exists).

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -42,20 +42,6 @@ const packageJsonPath = join(root, "package.json");
 const packageJson = await readJson(packageJsonPath);
 const nextVersion = bumpVersion(packageJson.version, releaseType);
 
-// Keep the root optionalDependencies (the native binary sub-packages) in sync
-// with the package version. They must point at the same version the
-// npm/<platform>/ sub-packages are published at, otherwise installs resolve
-// to a previous release's native binaries (a real off-by-one version skew).
-const subPackagePrefix = `${packageJson.name}-`;
-
-if (packageJson.optionalDependencies) {
-  for (const dep of Object.keys(packageJson.optionalDependencies)) {
-    if (dep.startsWith(subPackagePrefix)) {
-      packageJson.optionalDependencies[dep] = nextVersion;
-    }
-  }
-}
-
 packageJson.version = nextVersion;
 
 await writeJson(packageJsonPath, packageJson);


### PR DESCRIPTION
Fixes the chicken-and-egg that #118's approach introduced. Moves the `optionalDependencies` sync from **prepare time** to **publish time**.

## What broke

#118 added the sync to `prepare-release.mjs`. But at prepare time, the new sub-package versions (e.g. `0.6.1`) **don't exist on npm yet** — they're published *during* the release. So the release workflow failed:

```
ERR_PNPM_OUTDATED_LOCKFILE: 6 dependencies were added:
  @litko/yara-x-*@0.6.1
```

`pnpm install --lockfile-only` couldn't resolve the unpublished versions, left the lockfile stale, and `--frozen-lockfile` verification failed.

## The fix

**Move the sync to the CI publish job** (`CI.yml`), right between the sub-package publish loop and the root publish:

```
1. Publish platform sub-packages   ← 0.6.1 sub-packages now exist on npm
2. Sync optionalDependencies        ← write 0.6.1 into root package.json (NEW)
3. Publish main package             ← root published with correct optionalDeps
```

At publish time the versions exist on npm, so there's no resolution issue. The sync only touches deps matching `<rootName>-`, so it's scoped to this package's native sub-packages.

## Changes

1. **`scripts/prepare-release.mjs`** — revert #118's sync block. Committed `optionalDependencies` stay at the last-published version (which resolves in the lockfile).
2. **`.github/workflows/CI.yml`** — add a `Sync optionalDependencies to current version` step before the root publish.

The `package.json` correction (0.5.2 → 0.6.0) from #118 stays on main.

## Why this is correct

| Layer | optionalDeps state | Resolves on npm? |
|---|---|---|
| Committed repo / lockfile | last-published version | ✅ yes |
| Published npm artifact | current version (synced at publish) | ✅ yes (sub-pkgs published first) |
