### PR TITLE
ci: skip native build/test when source is unchanged

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,8 +106,46 @@ jobs:
 
           echo "build_matrix={\"settings\":$BUILD_MATRIX}" >> $GITHUB_OUTPUT
           echo "test_matrix={\"settings\":$TEST_MATRIX,\"node\":[\"22\"]}" >> $GITHUB_OUTPUT
+  # Detect whether build inputs changed. The expensive native build/test
+  # matrix is skipped on PRs and pushes that don't touch Rust source, build
+  # config, or tests — e.g. workflow-only, docs, or script-only changes.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.diff.outputs.src }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+      - name: Detect source changes
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          EVENT="${{ github.event_name }}"
+          # Release, manual dispatch, and any other non-push/PR event always build.
+          if [[ "$EVENT" != "pull_request" && "$EVENT" != "push" ]]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$EVENT" == "pull_request" ]]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          # Fall back to "build" if the base commit is unavailable (first push, force-push).
+          if ! git rev-parse --verify --quiet "${BASE}" >/dev/null; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "${BASE}..HEAD" | grep -qxE 'src/.*|__test__/.*|Cargo.toml|Cargo.lock|build.rs|package.json|index.js|index.d.ts'; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi
   build:
-    needs: setup
+    needs: [setup, changes]
+    if: needs.changes.outputs.src == 'true'
     permissions:
       attestations: write
       contents: read
@@ -164,6 +202,8 @@ jobs:
     needs:
       - setup
       - build
+      - changes
+    if: needs.changes.outputs.src == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.test_matrix) }}


### PR DESCRIPTION
Skips the native build/test matrix when source hasn't changed. Stacked on #119 — rebase to `main` after that merges (no conflict expected; this only adds a job + two `if:` lines).

## The problem (measured on #119, which changes zero Rust source)

The cargo cache **hits fully** — the big `yara-x` dependency is not recompiled, only the tiny wrapper:

```
stable - x86_64-apple-darwin  : Cache hit (full match, 357 MB) → Finished `release` in 2m 09s
stable - x86_64-pc-windows-msvc: Cache hit (full match)        → Finished `release` in 4m 37s
```

The 2–6 min is unavoidable per-run cost: runner setup + ~357 MB cache restore + compiling the wrapper + the **LTO link**. The release profile forces a full LTO relink every build (`lto=true`, `codegen-units=1`, `CARGO_INCREMENTAL=0`), so the cache can't eliminate it. **Only not running the job can.**

## The fix

A `changes` job diffs the commit against its base and outputs `src` = whether build inputs changed:

```
src/  __test__/  Cargo.toml  Cargo.lock  build.rs  package.json  index.js  index.d.ts
```

`build` and `test-bindings` are gated on `needs.changes.outputs.src == 'true'`. Workflow-only / docs / script-only PRs (and their post-merge pushes) skip the matrix entirely → ~30 s instead of ~7 min.

## Safety (verified)

| Event | `changes` | build/test | publish |
|---|---|---|---|
| `release` | `src=true` (forced) | run | runs (artifacts present) ✅ |
| `workflow_dispatch` on main | `src=true` (forced) | run | runs ✅ |
| `schedule` | `src=true` (forced) | run | n/a |
| non-source PR (#119-style) | `src=false` | **skipped** | n/a |
| source PR | `src=true` | run | n/a |

- The publish path is unaffected: `release`/`dispatch` always force `src=true`, so build runs and publish has its artifacts.
- `test-bindings` skips automatically when `build` is skipped (implicit `success()`).
- The detector only skips when source files are **identical** between base and head, so it can never skip a genuinely-needed build. First-push / force-push sentinels (`before` = zeros) fall back to `src=true`.

## Not in this PR (follow-up if you want it)

Even source-change builds pay the LTO link. A common further optimization is a **fast CI build profile** (no LTO, more codegen units, incremental on) for PR verification, reserving full LTO for the release publish. That trades "test exactly what you ship" for ~2–4× faster source-change builds. Separate PR if you want it.

## Checklist
- [x] YAML valid; all five jobs present (`setup, changes, build, test-bindings, publish`)
- [x] `build`/`test-bindings` gated on `src`
- [x] Release/dispatch/schedule force `src=true` (publish safety)
- [x] Detector only skips on identical source (no false negatives)
- [x] Stacked on #119, no expected conflict
