### PR TITLE
ci: sign release assets with Sigstore (OpenSSF Signed-Releases)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -311,3 +311,44 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cosign
+        # Keyless Sigstore signing via the GitHub OIDC token (id-token: write).
+        # Used to sign the native .node artifacts attached to the release.
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Sign and attach release assets
+        # Attach the native .node binaries to the GitHub release and sign each
+        # one keyless with Sigstore (producing a .sigstore bundle). This is what
+        # the OpenSSF Scorecard 'Signed-Releases' check looks for (signature
+        # files among the release assets), and lets consumers verify downloads:
+        #   cosign verify-blob --bundle yara-x.<target>.node.sigstore \
+        #     yara-x.<target>.node \
+        #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+        # (the certificate identity is this repo's CI workflow, at the ref that
+        # ran the publish job). Runs after npm publish so a signing failure never
+        # blocks the package.
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG does not exist; skipping release-asset signing."
+            exit 0
+          fi
+          mkdir -p release-assets
+          # Flatten the platform-named .node binaries into one directory.
+          find npm -type f -name '*.node' -exec cp {} release-assets/ \;
+          echo "Collected $(ls release-assets/*.node | wc -l | tr -d ' ') native artifacts:"
+          ls -1 release-assets/
+          cd release-assets
+          # Sign each binary keyless; --bundle writes a Sigstore bundle (.sigstore).
+          for f in *.node; do
+            echo "Signing $f ..."
+            cosign sign-blob --yes --bundle "${f}.sigstore" "$f"
+          done
+          cd ..
+          gh release upload "$TAG" release-assets/*.node release-assets/*.sigstore --clobber
+          echo "Attached $(ls release-assets/*.sigstore | wc -l | tr -d ' ') signed assets to $TAG"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Attaches signed native binaries to the GitHub release, lifting the OpenSSF `Signed-Releases` check from 0 → 8.

## The gap (verified)

The `Signed-Releases` check is **0**. It looks for signature/provenance files among **GitHub release assets** — specifically extensions `.sig`, `.sigstore`, `.asc`, `.minisig`, `.sign`, `.intoto.jsonl`.

Your releases currently have **zero assets**: `create-release.yml` runs `gh release create --generate-notes` and uploads nothing. Your signing exists, but on the wrong layers for this check:
- npm `--provenance` → attached to the npm package (`Packaging` = 10, separate check)
- `actions/attest@v4` on `.node` files → attached to the workflow run, not the release

So `Signed-Releases` sees empty releases and scores 0.

## The fix

Two new steps in the CI **publish job**, after `npm publish` (so a signing failure never blocks the package):

1. **Install cosign** — `sigstore/cosign-installer@<commit>` (pinned by SHA)
2. **Sign and attach release assets**:
   - Collect the platform-named `.node` binaries (`npm/*/*.node`)
   - Sign each **keyless with Sigstore** → `cosign sign-blob --yes --bundle <file>.sigstore` (uses the publish job's `id-token: write` via GitHub OIDC; no key management)
   - `gh release upload` both the `.node` binaries and their `.sigstore` bundles to the release
   - Guarded: only runs if the release (`v<version>`) already exists

Permissions are already in place — the publish job has `contents: write` (release upload) + `id-token: write` (keyless signing) + `environment: main`. No new secrets, no keys to manage (Sigstore keyless).

## Scoring

- **Signature files in release assets → score 8** (`.sigstore` is recognized)
- Score 10 would require a `.intoto.jsonl` SLSA provenance file — a possible follow-up via `slsa-framework/slsa-github-generator`, heavier setup. This PR gets the bulk of the value simply.

## Verification limitation (please note)

This PR changes `CI.yml`, so the CI build matrix runs on the PR — but the new signing steps live in the **publish job**, which only runs on `release` / `workflow_dispatch` events, never on PRs. So the signing logic **cannot be exercised on this PR run**; it validates on the next actual release. YAML is validated; the cosign `sign-blob --yes --bundle <out>.sigstore` syntax is standard cosign v2 keyless. After merge, the next release (or a `gh workflow run CI.yml --ref main` after a release exists) will exercise it end-to-end.

## Consumer benefit (real, not just score)

Consumers can now verify downloaded binaries against the Sigstore transparency log:
```
cosign verify-blob --bundle yara-x.<target>.node.sigstore \
  yara-x.<target>.node \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```
(the certificate identity is this repo's CI workflow, at the ref that ran publish)

## Checklist
- [x] YAML valid; signing steps placed after npm publish
- [x] Reuses existing `id-token: write` + `contents: write` (no new perms/keys)
- [x] cosign-installer pinned by commit SHA (not tag object)
- [x] Guarded on release existence; signing failure doesn't block npm
- [x] `.sigstore` extension recognized by the Signed-Releases check
