### PR TITLE
ci: run Dependency Review on all PRs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,12 +1,12 @@
 name: Dependency Review
 "on":
   pull_request:
-    paths:
-      - Cargo.lock
-      - Cargo.toml
-      - package.json
-      - pnpm-lock.yaml
-      - .github/workflows/**
+    # Runs on every PR. `actions/dependency-review-action` exits success
+    # when there are no dependency changes ("no dependency changes to
+    # review"), so this required check always reports and stays
+    # satisfiable for source-only PRs.
+    branches:
+      - main
 permissions:
   contents: read
 env:


### PR DESCRIPTION
## Problem

`Dependency Review` is a **hard-required** check in the `main` ruleset (id `4316850`): `strict_required_status_checks_policy: true`, no bypass actors. But the workflow that produces it was **path-filtered**:

```yaml
"on":
  pull_request:
    paths:                       # only runs if PR touches one of these
      - Cargo.lock
      - Cargo.toml
      - package.json
      - pnpm-lock.yaml
      - .github/workflows/**
```

For a **source-only PR** the workflow never runs → the required check never reports → the merge button is permanently frozen (*"Expected — Waiting for status to be reported"*).

PR #131 was the first pure-source feature PR to hit this. Every prior merge touched a matching path by coincidence (Dependabot → manifests, `ci:` PRs → `.github/workflows/**`, release fixes → `package.json`), so the latent config mismatch stayed hidden. **This would block every future source-only PR.**

## Fix

Drop the `paths:` filter so the workflow runs on every PR targeting `main`.

`actions/dependency-review-action@v5` exits **success** when there are no dependency changes (*"no dependency changes to review"*), so the required check always reports and stays satisfiable for source-only PRs — the GitHub-recommended setup for a hard-required Dependency Review check.

## Self-validating

This PR changes only `.github/workflows/dependency-review.yml`, so it **does** run the workflow. If `Dependency Review` passes here (no manifest diff → expected success), the fix is empirically proven before this PR merges — and PR #131 will unblock once it rebases onto the updated `main`.

## Verification
- [x] Valid YAML (`yaml.safe_load`)
- [x] Minimal, additive change to the `on:` trigger only