### PR TITLE
ci(prepare-release): build native binding from source before testing

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -71,6 +71,20 @@ jobs:
       - name: Install dependencies
         if: steps.release.outputs.skip != 'true'
         run: pnpm install --frozen-lockfile
+      - name: Install Rust toolchain
+        # Build the native binding from source so verification tests the
+        # current commit, not the previously-published optional-dependency
+        # binary. Without this, `pnpm test` resolves @litko/yara-x-<platform>
+        # from npm (a prior release built against an older yara-x) and any
+        # test exercising newer compiler behavior fails spuriously.
+        if: steps.release.outputs.skip != 'true'
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: stable
+      - name: Install native build dependencies
+        # yara-x's build requires protoc (protobuf-compiler).
+        if: steps.release.outputs.skip != 'true'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler
       - name: Prepare version bump
         if: steps.release.outputs.skip != 'true'
         id: bump
@@ -86,6 +100,7 @@ jobs:
         if: steps.release.outputs.skip != 'true'
         run: |
           pnpm install --frozen-lockfile
+          pnpm build:debug
           cargo metadata --locked --format-version 1 >/dev/null
           pnpm test
       - name: Setup Keyless Signing (Gitsign)


### PR DESCRIPTION
## Problem

The `v0.7.0` prepare-release run **failed** at `Verify release prep` (7 tests), even though the same 83 tests were green in PR #131's `Test bindings` job.

Root cause: `prepare-release.yml`'s `Verify release prep` step runs `pnpm test` **without building the native `.node`**. On the ubuntu runner, `index.js`'s `requireNative()` then falls through to the installed optional-dependency — `@litko/yara-x-linux-x64-gnu` from **npm**, which is the **previously published 0.6.1 binary (yara-x 1.18)**, not the current source.

Confirmed in the failed run log:
```
Install dependencies: + @litko/yara-x-linux-x64-gnu 0.6.1   ← stale published binary
```

So the 7 new `slow_pattern` / `duplicate_pattern_value` warning tests (which depend on yara-x **1.19** behavior) ran against a 1.18 binary and correctly found no warnings → spurious failures. This would block **any** future release whose tests exercise post-1.18 compiler behavior.

The CI.yml `Test bindings` job didn't hit this because it downloads the **freshly-built release artifact** (from source), not the npm package.

## Fix

Build the native binding from source before `pnpm test`:
- Add `dtolnay/rust-toolchain@...` (stable)
- Install `protobuf-compiler` (yara-x build requirement)
- Run `pnpm build:debug` in `Verify release prep` before `pnpm test`

Now the step verifies the **current commit**, not a stale published binary.

## Verification

Reproduced the failure mode and the fix in a clean `node:22` / `linux/amd64` container:

| Rule | stale npm binary (1.18) | from-source build (1.19) |
|---|---|---|
| `$a = "a"` | `[]` ❌ | `["slow_pattern"]` ✅ |
| two single-byte | `[]` ❌ | `["slow_pattern","slow_pattern"]` ✅ |
| dup `"hello"` | `[]` ❌ | `["duplicate_pattern_value"]` ✅ |
| `{ 00 00 00 00 }` | `[]` ❌ | `["slow_pattern"]` ✅ |

From-source linux-x64 build → all 83 tests pass.

## Notes
- `build:debug` (not `build`) keeps the verify step fast; release artifacts are still built fresh by CI.yml's `build` job at publish time.
- Additive only (15 lines); no existing behavior changed.