### PR TITLE
feat: add serialize/deserialize APIs for compiled rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,48 @@ compiledRules.emitWasmFile("./output/instance_rules.wasm");
 await compiledRules.emitWasmFileAsync("./output/async_rules.wasm");
 ```
 
+> **Note:** `emitWasmFile` produces a debug artifact (the raw WASM module of
+> compiled conditions) for inspection with tools like `wasm2wat`. It is **not**
+> a distributable rules format. Use `serialize()` / `deserialize()` below to
+> ship compiled rules between machines.
+
+## Rules Serialization
+
+Compiled rules can be serialized to a compact, self-contained binary blob and
+restored on any platform that uses the same YARA-X version (1.19.x). The blob
+carries the patterns, regex data, global variables, and compiled WASM
+conditions; conditions are recompiled for the local platform on load (~1-2ms).
+
+```javascript
+import { compile, deserialize } from "@litko/yara-x";
+
+// Producer: compile once, ship the blob
+const rules = compile(`
+  rule example {
+    strings:
+      $a = "malware"
+    condition:
+      $a
+  }
+`);
+const blob = rules.serialize();            // Buffer, a few KiB for typical rule sets
+await Bun.write("./rules.yarx", blob);    // or writeFileSync / DB / CDN
+
+// Consumer: restore and scan at native speed
+const restored = deserialize(await Bun.file("./rules.yarx").arrayBuffer());
+restored.scan(buffer);                    // all scan APIs work: scan,
+restored.scanFile("./suspect.bin");      // scanFile, scanAsync, scanFileAsync
+```
+
+Notes:
+
+- The blob is version-locked: producer and consumer must use the same YARA-X
+  version, and must be built with the same set of modules (e.g. rules using
+  `import "pe"` need the `pe` module in the consumer's build).
+- Serialization is **not** obfuscation: rule strings remain extractable.
+- Deserializing a blob produced by `emitWasmFile` (or arbitrary bytes) fails
+  with a clear error.
+
 ## Incremental Rule Building
 
 ```javascript

--- a/__test__/index.spec.mjs
+++ b/__test__/index.spec.mjs
@@ -1,7 +1,7 @@
 import yarax from "../index.js";
-import { existsSync, mkdirSync, writeFileSync, rmSync, statSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync, rmSync, statSync, readFileSync } from "fs";
 import { join, dirname } from "path";
-import { strictEqual, ok, fail, throws } from "assert";
+import { strictEqual, ok, fail, throws, deepStrictEqual } from "assert";
 import { describe, it, before, after } from "node:test";
 import { fileURLToPath } from "url";
 
@@ -1724,5 +1724,126 @@ rule test_1 {
         ok(matches2.length > 0, "Should match rule from second include dir");
       });
     });
+
+    describe("Rules Serialization (serialize/deserialize)", () => {
+    const serializeRule = `
+      rule serialized_rule {
+        meta:
+          author = "test"
+        strings:
+          $a = "needle"
+          $b = /needle[0-9]+/
+        condition:
+          any of them
+      }
+      rule serialized_other {
+        strings:
+          $c = "haystack"
+        condition:
+          $c and not serialized_rule
+      }
+    `;
+
+    it("should serialize compiled rules to a Buffer with YARA-X magic", () => {
+      const rules = yarax.compile(serializeRule);
+      const blob = rules.serialize();
+      ok(Buffer.isBuffer(blob), "serialize() should return a Buffer");
+      ok(blob.length > 0, "serialized blob should not be empty");
+      ok(
+        blob.subarray(0, 6).toString("utf8").startsWith("YARA-X"),
+        "blob should start with the YARA-X magic",
+      );
+    });
+
+    it("should round-trip rules with identical scan results", () => {
+      const rules = yarax.compile(serializeRule);
+      const restored = yarax.deserialize(rules.serialize());
+
+      const payload = Buffer.from("a needle in a haystack needle42");
+      const original = rules.scan(payload);
+      const roundTripped = restored.scan(payload);
+
+      strictEqual(roundTripped.length, original.length, "same number of matching rules");
+      strictEqual(roundTripped[0].ruleIdentifier, original[0].ruleIdentifier);
+      strictEqual(roundTripped[0].matches.length, original[0].matches.length);
+      strictEqual(roundTripped[0].matches[0].data, original[0].matches[0].data);
+      strictEqual(roundTripped[0].matches[0].offset, original[0].matches[0].offset);
+      deepStrictEqual(roundTripped[0].meta, original[0].meta, "metadata should survive");
+      strictEqual(restored.scan(Buffer.from("nothing here")).length, 0);
+    });
+
+    it("should scan files with deserialized rules", () => {
+      const rules = yarax.compile(
+        `rule file_rule { strings: $a = "file content" condition: $a }`,
+      );
+      const restored = yarax.deserialize(rules.serialize());
+      const tempFile = createTempFile("This is file content for serialized scanning");
+      const matches = restored.scanFile(tempFile);
+      strictEqual(matches.length, 1);
+      strictEqual(matches[0].ruleIdentifier, "file_rule");
+    });
+
+    it("should scan asynchronously with deserialized rules", async () => {
+      const rules = yarax.compile(`rule async_rule { strings: $a = "async" condition: $a }`);
+      const restored = yarax.deserialize(rules.serialize());
+      const matches = await restored.scanAsync(Buffer.from("scan async here"));
+      strictEqual(matches.length, 1);
+      strictEqual(matches[0].ruleIdentifier, "async_rule");
+    });
+
+    it("should preserve compile-time variables in the serialized blob", () => {
+      const rule = `rule var_rule { condition: test_var == 100 }`;
+      const rules = yarax.compile(rule, { defineVariables: { test_var: "100" } });
+      const restored = yarax.deserialize(rules.serialize());
+      const matches = restored.scan(Buffer.from("x"));
+      strictEqual(matches.length, 1, "variable should survive serialization");
+    });
+
+    it("should apply scan-time options to deserialized rules", () => {
+      const rules = yarax.compile(`rule m { strings: $a = "a" condition: $a }`);
+      const restored = yarax.deserialize(rules.serialize());
+      restored.setMaxMatchesPerPattern(1);
+      const matches = restored.scan(Buffer.from("aaa"));
+      strictEqual(matches.length, 1);
+      strictEqual(matches[0].matches.length, 1, "max matches per pattern should apply");
+    });
+
+    it("should reject garbage input on deserialize", () => {
+      throws(() => yarax.deserialize(Buffer.from("not a yara-x blob")), /deserialize/i);
+      throws(() => yarax.deserialize(Buffer.alloc(0)), /deserialize/i);
+    });
+
+    it("should reject the emitWasmFile debug artifact on deserialize", () => {
+      const rules = yarax.compile(serializeRule);
+      const wasmPath = join(__tempDir, `serialized-${Date.now()}.wasm`);
+      rules.emitWasmFile(wasmPath);
+      const wasmBytes = readFileSync(wasmPath);
+      ok(
+        wasmBytes.subarray(0, 4).equals(Buffer.from([0, 97, 115, 109])),
+        "emitWasmFile should produce a wasm module",
+      );
+      throws(
+        () => yarax.deserialize(wasmBytes),
+        /deserialize/i,
+        "wasm debug artifact is not a serialized rules blob",
+      );
+    });
+
+    it("should report that source code is unavailable after deserialize", () => {
+      const rules = yarax.compile(`rule r { strings: $a = "x" condition: $a }`);
+      const restored = yarax.deserialize(rules.serialize());
+      const wasmPath = join(__tempDir, `nosource-${Date.now()}.wasm`);
+      throws(() => restored.emitWasmFile(wasmPath), /source code not available/i);
+    });
+
+    it("should round-trip a blob written to and read from disk", () => {
+      const rules = yarax.compile(serializeRule);
+      const blobPath = join(__tempDir, `rules-${Date.now()}.yarx`);
+      writeFileSync(blobPath, rules.serialize());
+      const restored = yarax.deserialize(readFileSync(blobPath));
+      strictEqual(restored.scan(Buffer.from("needle")).length, 1);
+      strictEqual(restored.scan(Buffer.from("haystack")).length, 1);
+    });
+  });
   });
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,19 @@ export declare class YaraX {
    */
   emitWasmFile(outputPath: string): void
   /**
+   * Serializes the compiled YARA rules to a portable binary blob.
+   *
+   * The serialized blob is self-contained (patterns, regex data, globals, and
+   * the compiled WASM conditions) and can be restored on any platform with
+   * the [`deserialize`](crate::deserialize) function, provided the same
+   * YARA-X version is used on both sides.
+   *
+   * # Returns
+   *
+   * A Buffer containing the serialized rules
+   */
+  serialize(): Buffer
+  /**
    * Scans the provided data asynchronously using the compiled YARA rules.
    *
    * # Arguments
@@ -348,6 +361,25 @@ export declare function compileToWasm(ruleSource: string, outputPath: string, op
  * A new YaraX instance with empty rules
  */
 export declare function create(): YaraXImpl
+
+/**
+ * Creates a new YaraX instance from a serialized rules blob.
+ *
+ * The blob must have been produced by [`YaraX::serialize`] (or
+ * `yara_x::Rules::serialize`) using the same YARA-X version. The rules are
+ * restored with full scanning capability (including WASM condition
+ * recompilation for the current platform) and can be used with `scan`,
+ * `scan_file`, `scan_async`, and `scan_file_async`.
+ *
+ * # Arguments
+ *
+ * * `data` - Buffer containing the serialized rules
+ *
+ * # Returns
+ *
+ * A YaraX instance with the restored rules
+ */
+export declare function deserialize(data: Buffer): YaraXImpl
 
 /**
  * Creates a new YaraX instance from a file containing YARA rules.

--- a/index.js
+++ b/index.js
@@ -705,5 +705,6 @@ module.exports.compile = nativeBinding.compile
 module.exports.compileFileToWasm = nativeBinding.compileFileToWasm
 module.exports.compileToWasm = nativeBinding.compileToWasm
 module.exports.create = nativeBinding.create
+module.exports.deserialize = nativeBinding.deserialize
 module.exports.fromFile = nativeBinding.fromFile
 module.exports.validate = nativeBinding.validate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@ pub use types::{
 // Internal imports
 use compiler::{add_source_to_compiler, apply_compiler_options};
 use error::io_error_to_napi;
-use napi::Result;
+use napi::bindgen_prelude::Buffer;
+use napi::{Error, Result, Status};
 use napi_derive::napi;
 use scanner::YaraX as YaraXImpl;
 use std::path::Path;
@@ -142,6 +143,48 @@ pub fn from_file(rule_path: String, options: Option<CompilerOptionsType>) -> Res
     .map_err(|e| io_error_to_napi(e, &format!("reading file {rule_path}")))?;
 
   YaraXImpl::create_scanner_from_source(file_content, options)
+}
+
+/// Creates a new YaraX instance from a serialized rules blob.
+///
+/// The blob must have been produced by [`YaraX::serialize`] (or
+/// `yara_x::Rules::serialize`) using the same YARA-X version. The rules are
+/// restored with full scanning capability (including WASM condition
+/// recompilation for the current platform) and can be used with `scan`,
+/// `scan_file`, `scan_async`, and `scan_file_async`.
+///
+/// # Arguments
+///
+/// * `data` - Buffer containing the serialized rules
+///
+/// # Returns
+///
+/// A YaraX instance with the restored rules
+#[napi]
+pub fn deserialize(data: Buffer) -> Result<YaraXImpl> {
+  use std::cell::RefCell;
+  use std::sync::Arc;
+  use yara_x::Rules;
+
+  let rules = Rules::deserialize(data.as_ref()).map_err(|e| {
+    Error::new(
+      Status::InvalidArg,
+      format!("Failed to deserialize rules: {e}"),
+    )
+  })?;
+
+  Ok(YaraXImpl {
+    rules: Arc::new(rules),
+    source_code: None,
+    rule_sources: Vec::new(),
+    warnings: Vec::new(),
+    variables: None,
+    cached_scanner: RefCell::new(None),
+    max_matches_per_pattern: None,
+    use_mmap: None,
+    timeout_ms: None,
+    match_context_size: None,
+  })
 }
 
 /// Compiles a YARA rule source string to a WASM file.

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -506,6 +506,28 @@ impl YaraX {
     }
   }
 
+  /// Serializes the compiled YARA rules to a portable binary blob.
+  ///
+  /// The serialized blob is self-contained (patterns, regex data, globals, and
+  /// the compiled WASM conditions) and can be restored on any platform with
+  /// the [`deserialize`](crate::deserialize) function, provided the same
+  /// YARA-X version is used on both sides.
+  ///
+  /// # Returns
+  ///
+  /// A Buffer containing the serialized rules
+  #[napi]
+  pub fn serialize(&self) -> Result<Buffer> {
+    let bytes = self.rules.serialize().map_err(|e| {
+      Error::new(
+        Status::GenericFailure,
+        format!("Failed to serialize rules: {e}"),
+      )
+    })?;
+
+    Ok(Buffer::from(bytes))
+  }
+
   /// Scans the provided data asynchronously using the compiled YARA rules.
   ///
   /// # Arguments


### PR DESCRIPTION
## Summary

Adds `YaraX#serialize()` and module-level `deserialize()` so compiled rules can be distributed as a compact, self-contained blob instead of shipping rule source code everywhere.

Follow-up to the footprint research: `emitWasmFile` turns out to be yara-x's **debug artifact** (raw wasm conditions module — not loadable as rules), while `Rules::serialize()` is the real distributable format. This PR exposes the latter.

## What it provides

- **`serialize(): Buffer`** — a few KiB per typical rule set (31 rules ≈ 5.6 KiB, 1.9 KiB gzipped), carrying patterns, regex data, global variables, and compiled wasm conditions
- **`deserialize(data: Buffer): YaraX`** — restores rules in ~1–2 ms (conditions recompiled for the local platform on load), with **full scanning capability**: `scan`, `scanFile`, `scanAsync`, `scanFileAsync`, plus scan-time options (max matches, timeout, mmap, context size)
- **Portable across platforms** (x64/arm64, Linux/macOS/Windows) — same yara-x version required on both ends
- Clear errors: malformed input → `InvalidArg: Failed to deserialize rules: ...`; `emitWasmFile` output is rejected (not a rules format); deserialized instances correctly report source as unavailable for `emitWasmFile`

## Tests (93 total, all passing)

10 new tests: round-trip scan equivalence (matches/metadata/offsets), scanFile, scanAsync, compile-time variables survive serialization, scan options after deserialize, garbage + empty rejection, `emitWasmFile` artifact rejection, disk round-trip, source-unavailable error.

## Verification

- `npm test` ✓ 93/93
- `npm run build` (release) ✓
- `cargo test` ✓
- `cargo clippy --all-targets --all-features` ✓ 0 warnings

## Docs

README: new "Rules Serialization" section + note clarifying `emitWasmFile` is a debug artifact (for `wasm2wat` inspection), not a distributable format.
